### PR TITLE
PLENIGO-632-preview-functionality-for-aesop

### DIFF
--- a/plenigo_css/miniStopper.css
+++ b/plenigo_css/miniStopper.css
@@ -59,11 +59,15 @@ article .txt > p, article .txtblock > p {
     box-shadow: 10px 10px 5px 0px rgba(170,170,170,1);
 }
 
-#PlenigoLogin footer {
+#PlenigoLogin .PlenigoFooter {
     width: 100%;
     display: block;
     text-align: center;
     padding: 20px 0;
+}
+
+#PlenigoLogin .PlenigoFooter br {
+    display: none;
 }
 
 #PlenigoLogin p {
@@ -162,7 +166,7 @@ h3.Plenigo-login  {
 
 
 @media (max-width: 349px) {
-    #PlenigoLogin footer {
+    #PlenigoLogin .PlenigoFooter {
 
         text-align: center;
 

--- a/plenigo_plugin/PlenigoContentManager.php
+++ b/plenigo_plugin/PlenigoContentManager.php
@@ -63,16 +63,24 @@ class PlenigoContentManager
      */
     private $gaEventList = array();
 
+    /**
+     * Priority in which Plenigo will handle content. It has to be less than 10 
+     * (for shortcode processing) but more than 1.
+     */
+    const PLENIGO_CONTENT_PRIO = 5;
+    //Plenigo settings group
     const PLENIGO_SETTINGS_GROUP = 'plenigo';
     const PLENIGO_SETTINGS_NAME = 'plenigo_settings';
     const BOUGHT_STRING_FORMAT = "%s <p><p>Content bought with %s Thank you for your support";
     const MORE_SPLITTER = '<span id="more-';
     const JS_BASE_URL = "https://www.plenigo.com";
     const JS_BASE_URL_NOAUTH = "https://www.plenigo.com";
+    // Render types
     const RENDER_FEED = 0;
     const RENDER_SINGLE = 1;
     const RENDER_SEARCH = 2;
     const RENDER_OTHER = 3;
+    //Replacement tags
     const REPLACE_PLUGIN_DIR = "<!--[PLUGIN_DIR]-->";
     const REPLACE_PRODUCT_NAME = "<!--[PRODUCT_NAME]-->";
     const REPLACE_PRODUCT_PRICE = "<!--[PRODUCT_PRICE]-->";
@@ -91,6 +99,7 @@ class PlenigoContentManager
     //Google Analytics
     const REPLACE_GA_CODE = "<!--[PLENIGO_GA_CODE]-->";
     const REPLACE_GA_EVENTS = "<!--[PLENIGO_GA_EVENTS]-->";
+    // Teaser smart detection
     const TEASER_SHORTCODES_CONTAINER = "aesop_content,pl_checkout,pl_checkout_button,pl_renew";
     const TEASER_SHORTCODES_SINGLE = "aesop_quote";
     const TEASER_HTML_CONTAINER = "p,div,table";
@@ -108,8 +117,8 @@ class PlenigoContentManager
      */
     public function __construct()
     {
-        add_filter('the_content', array($this, 'plenigo_handle_main_content'), 5);
-        add_filter('the_content_feed ', array($this, 'plenigo_handle_feed_content'), 5);
+        add_filter('the_content', array($this, 'plenigo_handle_main_content'), self::PLENIGO_CONTENT_PRIO);
+        add_filter('the_content_feed ', array($this, 'plenigo_handle_feed_content'), self::PLENIGO_CONTENT_PRIO);
         $this->options = get_option(self::PLENIGO_SETTINGS_NAME);
 
         add_action('wp_footer', array($this, 'plenigo_js_snippet'));
@@ -933,7 +942,7 @@ class PlenigoContentManager
             $fstWord = strtok($trimmedContent, ' '); //get the very first work, it should be [aesop_ or any other tag
             //if its a shortcode, check for allowed shortcodes and capture the teaser
             if (substr($fstWord, 0, 1) == '[') {
-                $this->addDebugLine("SHORTCODE" );
+                $this->addDebugLine("SHORTCODE");
                 $tag = strtolower(trim(substr($fstWord, 1)));
                 //First lets catch container tags
                 if (in_array($tag, $this->resolveArray(self::TEASER_SHORTCODES_CONTAINER))) {
@@ -949,7 +958,7 @@ class PlenigoContentManager
             }
             //if its a html tag, check for allowed html tags and capture the teaser
             if (substr($fstWord, 0, 1) == '<') {
-                $this->addDebugLine("HTML" );
+                $this->addDebugLine("HTML");
                 $tag = strtolower(trim(substr($fstWord, 1)));
                 //First lets catch container tags
                 if (in_array($tag, $this->resolveArray(self::TEASER_HTML_CONTAINER))) {

--- a/plenigo_template/plenigo-curtain-single.html
+++ b/plenigo_template/plenigo-curtain-single.html
@@ -15,13 +15,10 @@
 
         <p><!--[  PRODUCT _commented_ DETAILS   ]--></p>
 
-        <footer>
-            <button class="btn btn-default enp-button cust-pl-btn" 
-                    style="<!--[BUTTON_STYLE]-->" onclick="<!--[BUTTON_CLICK]-->"><!--[BUTTON_TITLE]--></button>
-            <button class="btn btn-default enp-button cust-pl-btn" 
-                    style="<!--[CUSTOM_STYLE]-->" onclick="<!--[CUSTOM_CLICK]-->"><!--[CUSTOM_TITLE]--></button>
-            <button class="btn btn-default enp-button cust-pl-btn" 
-                    style="<!--[LOGIN_STYLE]-->" onclick="<!--[LOGIN_CLICK]-->"><!--[LOGIN_TITLE]--></button>
-        </footer>
+        <div class="PlenigoFooter">
+            <button class="btn btn-default enp-button cust-pl-btn" style="<!--[BUTTON_STYLE]-->" onclick="<!--[BUTTON_CLICK]-->"><!--[BUTTON_TITLE]--></button>
+            <button class="btn btn-default enp-button cust-pl-btn" style="<!--[CUSTOM_STYLE]-->" onclick="<!--[CUSTOM_CLICK]-->"><!--[CUSTOM_TITLE]--></button>
+            <button class="btn btn-default enp-button cust-pl-btn" style="<!--[LOGIN_STYLE]-->" onclick="<!--[LOGIN_CLICK]-->"><!--[LOGIN_TITLE]--></button>
+        </div>
     </div>
 </div>

--- a/plenigo_wordpress.php
+++ b/plenigo_wordpress.php
@@ -4,7 +4,7 @@
   Plugin Name: Plenigo
   Plugin URI: http://wordpress.org/plugins/plenigo/
   Description: So far, the technical implementation of paid content has been time-consuming and costly for publishing houses and media companies. plenigo puts an end to this.
-  Version: 1.1.21
+  Version: 1.1.22
   Author: Plenigo
   Author URI: https://www.plenigo.com
   Text Domain: plenigo

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Sebastian Dieguez <s.dieguez@plenigo.com>
 Tags: paywall, e-commerce, Ecommerce, paid content software, subscriptions, newspaper, media, pay-per-read, pay, plugin, donate, money, transaction, bank, visa, mastercard, credit, debit, card, widget, give, pay what you want, plenigo, payment
 Requires at least: 3.9.2
 Tested up to: 4.1
-Stable tag: 1.1.21
+Stable tag: 1.1.22
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -94,6 +94,11 @@ A: Because we make Chuck Norris eat all his meal
 Coming soon
 
 == Changelog ==
+= 1.1.22 - Aesop and other plugin support =
+- Feature: Now supporting Aesop tags to be shown before showing the curtain
+- Fixed: a possible bug involving the footer tag in the HTML template
+- Note: now the content processing has more priority, please check your templates to avoid problems in the HTML
+
 = 1.1.21 - Fixes for URL redirect =
 - Fixed a problem with URL parameters being stored as a return URL
 


### PR DESCRIPTION
= 1.1.22 - Aesop and other plugin support =
- Feature: Now supporting Aesop tags to be shown before showing the curtain
- Fixed: a possible bug involving the footer tag in the HTML template
- Note: now the content processing has more priority, please check your templates to avoid problems in the HTML
