### PR TITLE
Fixing WooCommerce endpoints URLs

### DIFF
--- a/plenigo_wordpress.php
+++ b/plenigo_wordpress.php
@@ -9,6 +9,8 @@
   Author URI: https://www.plenigo.com
   Text Domain: plenigo
   License: GPLv2
+  WC requires at least: 2.2
+  WC tested up to: 2.4.5
  */
 /*
   Copyright (C) 2014 plenigo


### PR DESCRIPTION
- Now order id is calculated with several methods (luckly is not that fragile)
- Fixed a problem for products with downloads not detected as Download type product
- More stuff  for the quick debug report
