### PR TITLE
Update PlenigoSettingsPage.php

### DIFF
--- a/plenigo_plugin/PlenigoSettingsPage.php
+++ b/plenigo_plugin/PlenigoSettingsPage.php
@@ -231,7 +231,6 @@ class PlenigoSettingsPage
      */
     public function create_admin_page() {
         echo '<div class="wrap">';
-        screen_icon();
         echo '<h2>plenigo integration</h2>';
         settings_errors(self::PLENIGO_SETTINGS_PAGE);
 


### PR DESCRIPTION
`screen_icon()` was deprecated in WordPress 3.8 and is no longer used